### PR TITLE
switch to python alleviates the need to set python path

### DIFF
--- a/DevVM/Install-DevMachineSoftware.ps1
+++ b/DevVM/Install-DevMachineSoftware.ps1
@@ -59,10 +59,9 @@ $repoName = "IoTEdgeAndMlSample"
 if (!(Test-Path $repoName)) {
     & "C:\Program Files\Git\cmd\git.exe" clone https://$($GitHubUserName):$($GitHubPat)@github.com/Azure-Samples/$repoName.git
 }
-
 Pop-Location
 
-#add python scripts to the path	
+#add python scripts to the path
 $pythonPath = "$($env:Path);$($env:userprofile)\AppData\Roaming\Python\Python37\scripts"
 if (!$env:Path.Contains($pythonPath)) {
     [Environment]::SetEnvironmentVariable("Path", $pythonPath, [EnvironmentVariableTarget]::Machine)


### PR DESCRIPTION
## Purpose
replace miniconda with an install of python. Miniconda doesn't install correctly in our script and is unnecessary for our needs in this walkthrough.  