### PR TITLE
we are using the shell script so remove it and update csproj

### DIFF
--- a/LeafDevice/LeafDevice.csproj
+++ b/LeafDevice/LeafDevice.csproj
@@ -10,12 +10,6 @@
     <Content Include="..\Data\Turbofan\TestingSets\*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-     <Content Include=".\LeafDevice.sh">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include=".\azure-iot-test-only.root.ca.cert.pem">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.*" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/LeafDevice/LeafDevice.sh
+++ b/LeafDevice/LeafDevice.sh
@@ -1,3 +1,0 @@
-export DEVICE_CONNECTION_STRING="<device_connection_string>;GatewayHostName=<edge_device_fqdn>"
-export CA_CERTIFICATE_PATH=$(pwd)/azure-iot-test-only.root.ca.cert.pem
-./LeafDevice


### PR DESCRIPTION
## Purpose
Remove leafdevice.sh.  This script was a convenience if one were using an Azure VM leaf device, but we are no longer doing that.  The .pem file was in the csproj to deploy it to the leaf device, which is unnecessary.