### PR TITLE
Restrict Azure regions to those supported by ML Workspaces

### DIFF
--- a/DevVM/Create-AzureDevVm.ps1
+++ b/DevVM/Create-AzureDevVm.ps1
@@ -7,6 +7,7 @@ param
     [string] $ResourceGroupName,
 
     [Parameter(Mandatory = $True)]
+    [ValidateSet("Australia East", "East US", "East US 2", "South Central US", "Southeast Asia", "West Europe", "West Central US", "West US 2")]
     [string] $Location,
 
     [Parameter(Mandatory = $True)]


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* We want all resources to be in the same Azure location, but ML Workspaces are only supported in a sub set. By the time we get around to that, it is too late, so we should restrict available locations further upstream.