### PR TITLE
Add the events endpoint so monitoring D2C messages works

### DIFF
--- a/IoTHub/HubAndStorage.json
+++ b/IoTHub/HubAndStorage.json
@@ -100,6 +100,15 @@
                                 "turbofanDeviceStorage"
                             ],
                             "isEnabled": true
+                        },
+                        {
+                            "name": "events",
+                            "source": "DeviceMessages",
+                            "condition": "true",
+                            "endpointNames": [
+                                "events"
+                            ],
+                            "isEnabled": true
                         }
                     ]
                 }


### PR DESCRIPTION
In our steps we say to try monitoring D2C messages, but that won't work once we've added a message route. It will if we add the default endpoint as a custom one, though.