### PR TITLE
VMs must be running to run scripts; start docker

### DIFF
--- a/DevVM/Create-AzureDevVm.ps1
+++ b/DevVM/Create-AzureDevVm.ps1
@@ -153,6 +153,22 @@ Progress can be monitored from the Azure Portal (http://portal.azure.com).
 # Enable-HyperV -- Uses the vmname to enable Hyper-V on the VM.
 # 
 Function Install-Software($vmName) {
+    $vmInfo = Get-AzureRmVM -ResourceGroupName $ResourceGroupName -Name $vmName -Status
+    foreach ($state in $vmInfo.Statuses) {
+        if (!$state.Code.StartsWith("PowerState")) {
+            continue
+        }
+
+        if ($state.Code.Contains("running")) {
+            Write-Host "VM $vmName is running"
+            break
+        }
+        else {
+            Write-Host "Starting VM $vmName"
+            Start-AzureRmVM -ResourceGroupName $ResourceGroupName -Name $vmName
+        }
+    }
+
     Write-Host "`nEnabling Hyper-V in Windows on Azure VM..."
     Invoke-AzureRmVMRunCommand -ResourceGroupName $ResourceGroupName -Name $vmName -CommandId "RunPowerShellScript" -ScriptPath '.\Enable-HyperV.ps1' 2>&1>$null
     Write-Host "`nInstalling Chocolatey on Azure VM..."

--- a/DevVM/Enable-CodeExtensions.ps1
+++ b/DevVM/Enable-CodeExtensions.ps1
@@ -9,6 +9,12 @@
 #
 #*********************************************************
 
+#docker extension
+code --install-extension peterjausovec.vscode-docker
+Write-Host "Starting Docker desktop. When it finishes starting it will prompt you to login."
+Write-Host "You'll find the process running in the system tray (near the clock on the taskbar)."
+Start-Process -FilePath "c:\Program Files\Docker\Docker\Docker for Windows.exe"
+
 #iot extensions
 code --install-extension vsciot-vscode.azure-iot-tools
 
@@ -17,9 +23,6 @@ code --install-extension ms-python.python
 
 #dotnet extensions
 code --install-extension ms-vscode.csharp
-
-#docker extension
-code --install-extension peterjausovec.vscode-docker
 
 #powershell extension
 code --install-extension ms-vscode.PowerShell

--- a/EdgeVM/Create-EdgeVm.ps1
+++ b/EdgeVM/Create-EdgeVm.ps1
@@ -131,6 +131,22 @@ Progress can be monitored from the Azure Portal (http://portal.azure.com).
 # Install-Software -- Installs apt-get packages on the target VM
 # 
 Function Install-Software($vmName) {
+    $vmInfo = Get-AzureRmVM -ResourceGroupName $ResourceGroupName -Name $vmName -Status
+    foreach ($state in $vmInfo.Statuses) {
+        if (!$state.Code.StartsWith("PowerState")) {
+            continue
+        }
+
+        if ($state.Code.Contains("running")) {
+            Write-Host "VM $vmName is running"
+            break
+        }
+        else {
+            Write-Host "Starting VM $vmName"
+            Start-AzureRmVM -ResourceGroupName $ResourceGroupName -Name $vmName
+        }
+    }
+    
     Write-Host "`nInstalling apt-get packages..."
     Invoke-AzureRmVMRunCommand -ResourceGroupName $ResourceGroupName -Name $vmName -CommandId "RunShellScript" -ScriptPath '.\installpackages.sh'
 }


### PR DESCRIPTION
Docker takes a long time to start up. Rather than have the user run it when it is needed, and wait around for 2 minutes, start it when we install extensions.

When we remotely run scripts on the VMs, if the VM is stopped the script will fail. This can happen if the VM was partially created the day before and the VM was shutdown on a schedule. So before running the script, ensure the VM is running.