### PR TITLE
Increment iteration timeouts; set display output to True.

### DIFF
--- a/AzureNotebooks/01-turbofan_regression.ipynb
+++ b/AzureNotebooks/01-turbofan_regression.ipynb
@@ -318,7 +318,7 @@
         "trusted": true
       },
       "cell_type": "code",
-      "source": "import logging\nfrom azureml.train.automl import AutoMLConfig\n\n#name project folder and experiment\nexperiment_name = 'turbofan-regression-remote'\n\nautoml_settings = {\n    \"iteration_timeout_minutes\": 1,\n    \"iterations\": 10,\n    \"n_cross_validations\": 10,\n    \"primary_metric\": 'spearman_correlation',\n    \"max_cores_per_iteration\": -1,\n    \"enable_ensembling\": True,\n    \"ensemble_iterations\": 5,\n    \"verbosity\": logging.INFO,\n    \"preprocess\": True,\n    \"enable_tf\": True,\n    \"auto_blacklist\": True\n}\n\nAutoml_config = AutoMLConfig(task = 'regression',\n                             debug_log = 'auto-regress.log',\n                             path=script_folder,\n                             run_configuration=conda_run_config,\n                             data_script = script_folder + \"/get_data.py\",\n                             **automl_settings\n                            )",
+      "source": "import logging\nfrom azureml.train.automl import AutoMLConfig\n\n#name project folder and experiment\nexperiment_name = 'turbofan-regression-remote'\n\nautoml_settings = {\n    \"iteration_timeout_minutes\": 2,\n    \"iterations\": 10,\n    \"n_cross_validations\": 10,\n    \"primary_metric\": 'spearman_correlation',\n    \"max_cores_per_iteration\": -1,\n    \"enable_ensembling\": True,\n    \"ensemble_iterations\": 5,\n    \"verbosity\": logging.INFO,\n    \"preprocess\": True,\n    \"enable_tf\": True,\n    \"auto_blacklist\": True\n}\n\nAutoml_config = AutoMLConfig(task = 'regression',\n                             debug_log = 'auto-regress.log',\n                             path=script_folder,\n                             run_configuration=conda_run_config,\n                             data_script = script_folder + \"/get_data.py\",\n                             **automl_settings\n                            )",
       "execution_count": null,
       "outputs": []
     },
@@ -332,7 +332,7 @@
         "trusted": true
       },
       "cell_type": "code",
-      "source": "from azureml.core.experiment import Experiment\nfrom azureml.widgets import RunDetails\n\nexperiment=Experiment(ws, experiment_name)\nregression_run = experiment.submit(Automl_config, show_output=False)\nRunDetails(regression_run).show()",
+      "source": "from azureml.core.experiment import Experiment\nfrom azureml.widgets import RunDetails\n\nexperiment=Experiment(ws, experiment_name)\nregression_run = experiment.submit(Automl_config, show_output=True)\nRunDetails(regression_run).show()",
       "execution_count": null,
       "outputs": []
     },


### PR DESCRIPTION

## Purpose
1. Increment iteration timeouts to "2" minutes as some run over a minute.
2. Set default show_output to True, to display results from iterations.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```
