### PR TITLE
ms-vscode.csharp to ms-dotnettools.csharp

### DIFF
--- a/DevVM/Enable-CodeExtensions.ps1
+++ b/DevVM/Enable-CodeExtensions.ps1
@@ -22,7 +22,7 @@ code --install-extension vsciot-vscode.azure-iot-tools
 code --install-extension ms-python.python
 
 #dotnet extensions
-code --install-extension ms-vscode.csharp
+code --install-extension ms-dotnettools.csharp
 
 #powershell extension
 code --install-extension ms-vscode.PowerShell

--- a/DeviceHarness/README.md
+++ b/DeviceHarness/README.md
@@ -20,7 +20,7 @@ If you are not following the walk-through and using the recommended [development
 
   - [Azure Account and Sign-In](https://marketplace.visualstudio.com/items?itemName=ms-vscode.azure-account)
 
-  - [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+  - [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 
 ## Build and Run
 


### PR DESCRIPTION
C# extension has changed its name from "ms-vscode.csharp" to "ms-dotnettools.csharp", this means all extensions depending on it needs to be updated and i.e. all repositories with extension.json containing
```json
"recommendations": [
    "ms-vscode.csharp"
 ]
```
or you get errors like

![image](https://user-images.githubusercontent.com/1647294/76144809-2c18e500-6084-11ea-80ab-f365de742c99.png)