### PR TITLE
Update to VMTempate JSON

### DIFF
--- a/DevVM/IoTEdgeMLDemoVMTemplate.json
+++ b/DevVM/IoTEdgeMLDemoVMTemplate.json
@@ -5,6 +5,9 @@
         "location": {
             "type": "string"
         },
+        "region": {
+            "type": "string"
+        },
         "virtualMachineName": {
             "type": "string",
             "defaultValue": "[take(concat('IoTMLDemo-', uniqueString(resourceGroup().id, subscription().subscriptionId)), 15)]"
@@ -155,7 +158,7 @@
                     "imageReference": {
                         "publisher": "MicrosoftWindowsDesktop",
                         "offer": "Windows-10",
-                        "sku": "rs5-pro",
+                        "sku": "rs5-pro-g2",
                         "version": "latest"
                     }
                 },


### PR DESCRIPTION
rs5-pro does not have any available versions. Changing to g2 for current VM availability.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Added region property as both region and location are required for VM creation. Alos, the previous VM sku had no available versions, so I added "-g2"

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Once this and a fix in the Create-AzureDevVm.ps1 file are implemented, the DevVM will correctly deploy.

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* DevVM is correctly created and deployed.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
* This can be merged separate from the .ps1 file update, but must be merged first to prevent introducing a break in the code.